### PR TITLE
Annotation text

### DIFF
--- a/src/components/Ariadne/CircularViewer/CircularAnnotations/CircularAnnotation.tsx
+++ b/src/components/Ariadne/CircularViewer/CircularAnnotations/CircularAnnotation.tsx
@@ -1,16 +1,18 @@
 import { genArc } from "../circularUtils";
 import type { AnnotatedSequence, Annotation, Coor } from "@Ariadne/types";
+import { useState } from "react";
 
 export const CircularAnnotation = ({
   sequence,
   annotation,
   radius,
   center,
+  index,
 }: {
   sequence: AnnotatedSequence;
   radius: number;
   annotation: Annotation;
-
+  index: string;
   center: Coor;
 }) => {
   const { x: cx, y: cy } = center;
@@ -26,11 +28,32 @@ export const CircularAnnotation = ({
     center: { x: cx, y: cy },
   });
 
+  const [showAnnotation, setShowAnnotation] = useState(false);
+
+  const handleMouseOver = () => {
+    setShowAnnotation(true);
+  };
+  const handleMouseOut = () => {
+    setShowAnnotation(false);
+  };
   return (
-    <svg className={`${annotation.color} fill-current`}>
-      <path d={arcPath} fill="currentColor" stroke="currentColor">
-        <text>Annotation</text>
-      </path>
+    <svg
+      className={`${annotation.color} fill-current`}
+      onMouseOver={handleMouseOver}
+      onMouseOut={handleMouseOut}
+    >
+      <path id={`curve-${index}`} d={arcPath} />
+
+      <text
+        dx={5}
+        dy={5}
+        fill="black"
+        stroke="black"
+        alignmentBaseline="middle"
+        fontSize={"0.5rem"}
+      >
+        <textPath href={`#curve-${index}`}>test</textPath>
+      </text>
     </svg>
   );
 };

--- a/src/components/Ariadne/CircularViewer/CircularAnnotations/CircularAnnotationGutter.tsx
+++ b/src/components/Ariadne/CircularViewer/CircularAnnotations/CircularAnnotationGutter.tsx
@@ -25,13 +25,14 @@ export const CircularAnnotationGutter = ({
       <circle cx={cx} cy={cy} r={gutterRadius} fill="none" strokeWidth={0.8} />;
       {stackedAnnotations.map((annotations, stackIdx) => (
         <Fragment key={`annotation-stack-${stackIdx}`}>
-          {annotations.map((annotation) => (
+          {annotations.map((annotation, index) => (
             <CircularAnnotation
               key={`stack-${stackIdx}-${annotation.start}-${annotation.end}-${annotation.text}`}
               annotation={annotation}
               radius={gutterRadius + stackIdx * 6}
               center={{ x: cx, y: cy }}
               sequence={sequence}
+              index={`${stackIdx}${annotation.color}`}
             />
           ))}
         </Fragment>

--- a/src/components/Ariadne/LinearViewer/LinearViewer.tsx
+++ b/src/components/Ariadne/LinearViewer/LinearViewer.tsx
@@ -1,6 +1,6 @@
 import { stackElements } from "@Ariadne/utils";
 import { classNames } from "@utils/stringUtils";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import { AnnotatedSequence, Annotation } from "../types";
 
 export interface Props {
@@ -17,7 +17,7 @@ export const LinearViewer = (props: Props) => {
   const basesPerTick = Math.floor(sequence.length / numberOfTicks);
 
   return (
-    <div className="font-mono p-6 font-thin text-brand-400">
+    <div className="font-mono relative p-6 font-thin text-brand-400">
       <svg
         viewBox={`0 0 ${SVG_SIZE} ${SVG_SIZE}`}
         xmlns="http://www.w3.org/2000/svg"
@@ -71,21 +71,66 @@ const LinearAnnotationGutter = ({
       <line x1="0" y1="50%" x2="100%" y2="50%" stroke="currentColor" />
       {stackedAnnotations.map((annotations, stackIdx) => (
         <Fragment key={`annotation-stack-${stackIdx}`}>
-          {annotations.map((annotation) => (
-            <g
-              key={`annotation-${annotation.color}-${annotation.start}-${annotation.end}`}
-              className={classNames(annotation.color)}
-            >
-              <line
-                x1={`${(annotation.start / sequence.length) * 100}%`}
-                y1={`${50 + 3 * (stackIdx + 1)}%`}
-                x2={`${(annotation.end / sequence.length) * 100}%`}
-                y2={`${50 + 3 * (stackIdx + 1)}%`}
-                stroke="currentColor"
-                strokeWidth={10}
-              />
-            </g>
-          ))}
+          {annotations.map((annotation) => {
+            const [isHovering, setIsHovering] = useState(false);
+            const handleMouseOver = () => {
+              setIsHovering(true);
+            };
+
+            const handleMouseOut = () => {
+              setIsHovering(false);
+            };
+
+            return (
+              <g
+                key={`annotation-${annotation.color}-${annotation.start}-${annotation.end}`}
+                className={classNames(annotation.color)}
+                onMouseOver={handleMouseOver}
+                onMouseOut={handleMouseOut}
+              >
+                <line
+                  x1={`${(annotation.start / sequence.length) * 100}%`}
+                  y1={`${50 + 3 * (stackIdx + 1)}%`}
+                  x2={`${(annotation.end / sequence.length) * 100}%`}
+                  y2={`${50 + 3 * (stackIdx + 1)}%`}
+                  stroke="currentColor"
+                  strokeWidth={10}
+                />
+
+                {isHovering && (
+                  <g>
+                    <rect
+                      width="125"
+                      height="50"
+                      style={{ fill: "rgb(255,255,255)", position: "absolute" }}
+                      x={`${(annotation.start / sequence.length) * 100}%`}
+                      y={`${50 + 4 * (stackIdx + 1)}%`}
+                    />
+                    <line
+                      id={`tick-${stackIdx + 1}`}
+                      x1={`${(annotation.start / sequence.length) * 100}%`}
+                      y1={`${50 + 3 * (stackIdx + 1)}%`}
+                      x2={`${(annotation.start / sequence.length) * 100}%`}
+                      y2={`${50 + 5 * (stackIdx + 1)}%`}
+                      stroke="currentColor"
+                      strokeWidth={1}
+                    />
+                    <text
+                      x={`${(annotation.start / sequence.length) * 100 + 5}%`}
+                      y={`${50 + 5 * (stackIdx + 1)}%`}
+                      textAnchor="middle"
+                      fill="black"
+                      stroke="black"
+                      alignmentBaseline="middle"
+                      fontSize={"0.7rem"}
+                    >
+                      test annotation
+                    </text>
+                  </g>
+                )}
+              </g>
+            );
+          })}
         </Fragment>
       ))}
     </g>


### PR DESCRIPTION
Adresses #26

- Added annotation flags to linear viewer. I can't quite figure out how to do absolute positioning with svgs so that's why certain annotation svgs will overlap on top of the annotation text/flag when you mouse over them.
- Added annotation text to circular viewer. Had to add a new prop `index` to the `CircularAnnotation` component to uniquely assign annotation text.

In my mind there are two styles for annotation text: show a popup of the text on mouse hover of an annotation, or show the annotation text directly inside of the annotation svg. These features definitely need to be polished so lmk what you think.