### PR TITLE
refactor: update package.json to reflect correct css export

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
       "import": "./dist/nitro-sequence-viewers.es.js",
       "types": "./dist/index.d.ts"
     },
-    "./dist/nitro.css": {
-      "import": "./dist/nitro.css"
+      "./dist/nitro-sequence-viewers.css": {
+      "import": "./dist/nitro-sequence-viewers.css"
     }
   },
   "description": "collection of ui components",


### PR DESCRIPTION
 ## Summary
  - fix incorrect export path in `package.json`
  - `./dist/nitro.css` was declared in the `exports` field but the actual file is `./dist/nitro-sequence-viewers.css`
